### PR TITLE
Initial sketch of the Dataset portion of the Search API

### DIFF
--- a/DATASET.md
+++ b/DATASET.md
@@ -1,0 +1,148 @@
+# Dataset
+
+A `Dataset` is simply an array of objects that have a common set of properties. A Dataset can be thought of as a table where each cell represents the value of a property (column) for a particular object (row).
+
+A Dataset is made up of two blocks:
+
+1. `schema` describes properties of objects in the Dataset (e.g. "age")
+2. `objects` provide values for properties of objects in the Dataset (e.g. "age" : 30)
+
+### Schema
+
+The `schema` block follows the [Schema](SCHEMA.md) format.
+
+The root objects (items of the `objects` array) must be JSON objects. Their schema must have its `type` property equal to `"object"`, not a primitive value (`string`, `number`, ..) or array.
+  
+### Objects
+
+The content of the Dataset is provided in the `objects` block. Each object is a set of values with keys corresponding to keys in the `schema`.
+
+
+### Examples
+
+This is a Dataset with one schema property and two objects:
+
+```json
+{
+       "schema": {
+               "properties": {
+                       "age" : {
+                               "description": "age of a subject, in days",
+                               "type": "number"
+                       }
+               }
+       },
+       "objects": [
+               { "age": 30 },
+               { "age": 40 }
+       ]
+}
+
+```
+
+This is a Dataset that references an externally defined schema: the [Data Repository Service](https://github.com/ga4gh/data-repository-service-schemas) developed by the GA4GH Cloud Work Stream:
+
+```json
+{
+       "schema": {
+               "$ref": "http://schema.ga4gh.org/drs/0.1.0#/definitions/Object"
+       },
+       "objects": [
+               {
+                       "id": "file-001",
+                       "name": "file-001.txt",
+                       "size": 100,
+                       "created": "2019-01-01T12:00:01Z",
+                       "checksums": [
+                       ],
+                       "access_methods": [
+                               {
+                                       "type": "https"
+                               }
+                       ]
+               },
+               {
+                       "id": "file-002",
+                       "name": "file-002.txt",
+                       "size": 101,
+                       "created": "2019-01-01T12:00:00Z",
+                       "checksums": [
+                       ],
+                       "access_methods": [
+                               {
+                                       "type": "https"
+                               }
+                       ]
+               }
+       ]
+}
+```
+
+This is a Dataset whose [Schema](SCHEMA.md) mixes inline and externally referenced properties:
+
+
+```json
+{
+       "schema": {
+               "description": "A collection of subjects and their data objects",
+               "properties": {
+                       "subject": {
+                               "type": "object",
+                               "properties": {
+                                       "id": {
+                                               "description": "anonymous identifier of a subject",
+                                               "type": "string"
+                                       },
+                                       "age": {
+                                               "description": "age of a subject, in years",
+                                               "type": "number"
+                                       }
+                               }
+                       },
+                       "drs": {
+                               "$ref": "http://schema.ga4gh.org/drs/0.1.0#/definitions/Object"
+                       }
+               }
+       },
+       "objects": [
+               {
+                       "subject": {
+                               "id": "ABC100",
+                               "age": 30,
+                       },
+                       "drs": {
+                               "id": "file-001",
+                               "name": "file-001.txt",
+                               "size": 100,
+                               "created": "2019-01-01T12:00:01Z",
+                               "checksums": [
+                               ],
+                               "access_methods": [
+                                       {
+                                               "type": "https"
+                                       }
+                               ]
+                       }
+               },
+               {
+                       "subject": {
+                               "id": "ABC101",
+                               "age": 40,
+                       },
+                       "drs": {
+                               "id": "file-002",
+                               "name": "file-002.txt",
+                               "size": 101,
+                               "created": "2019-01-01T12:00:00Z",
+                               "checksums": [
+                               ],
+                               "access_methods": [
+                                       {
+                                               "type": "https"
+                                       }
+                               ]
+                       }
+               }
+       ]
+}
+```

--- a/README.md
+++ b/README.md
@@ -37,11 +37,15 @@ The following standards are complementary but not required by the Search framewo
     To edit this image, load assets/ga4gh-discovery-search.xml into draw.io and regenerate svg
 -->
 
+## Components
+
+Search API consists of [Dataset](DATASET.md) and Query APIs, describing search results and queries, respectively.
+
 ## Use cases
 
 See [USECASES.md](USECASES.md)
 
-Examples:
+### Examples
 
 * Find subjects with HP:0001519 and candidate gene FBN1 (use case of [Matchmaker Exchange](https://www.matchmakerexchange.org/))
 * Find male subjects with HP:0009726 consented for General Research Use (use case of [European Genome-phenome Archive](https://www.ebi.ac.uk/ega/home))

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -1,0 +1,84 @@
+# Schema
+
+A `Schema` describes [properties](#properties) of a [Dataset](DATASET.md).
+
+### Schema Format
+
+The Schema format follows [JSON-Schema](https://json-schema.org/) Draft 7.
+
+### Properties
+
+Schema `properties` describe attributes of [Datasets](DATASET.md) (e.g. a "subject" dataset may have an "age" property).
+
+Properties can be defined:
+
+- `inline` or 
+- `externally` by referencing a [JSON-Schema](https://json-schema.org/) definition
+
+#### Examples
+
+Here are sample Schema definitions. For more information, visit [the JSON-Schema website](https://json-schema.org/).
+
+##### Inline Properties
+
+This schema has one property, `age`, defined inline:
+
+```json
+{
+       "schema": {
+               "properties": {
+                       "age" : {
+                               "description": "age of a subject, in whole years",
+                               "type": "number"
+                       }
+               }
+       }
+}
+```
+
+##### Externally Defined Properties
+
+This schema defines its sole property, `drs`, by referring to an external data model: the [Data Repository Service](https://github.com/ga4gh/data-repository-service-schemas) developed by the GA4GH Cloud Work Stream:
+
+```json
+{
+       "schema": {
+               "properties": {
+                       "drs": {
+                               "$ref": "http://schema.ga4gh.org/drs/0.1.0#/definitions/Object"
+                       }
+               }
+       }
+}
+```
+
+##### Mixing Both
+
+This Schema that contains both inline and externally referenced properties:
+
+
+```json
+{
+       "schema": {
+               "description": "A collection of subjects and their data objects",
+               "properties": {
+                       "subject": {
+                               "type":"object",
+                               "properties": {
+                                       "id": {
+                                               "description": "anonymous identifier of a subject",
+                                               "type": "string"
+                                       },
+                                       "age": {
+                                               "description": "age of a subject, in whole years",
+                                               "type": "number"
+                                       }
+                               }
+                       },
+                       "drs": {
+                               "$ref": "http://schema.ga4gh.org/drs/0.1.0#/definitions/Object"
+                       }
+               }
+       }
+}
+```

--- a/spec/search-api.yaml
+++ b/spec/search-api.yaml
@@ -1,5 +1,4 @@
----
-openapi: "3.0.0"
+openapi: "3.0.2"
 info:
   title: GA4GH Discovery Search API
   description: Definition of GA4GH Discovery Search API

--- a/spec/search-api.yaml
+++ b/spec/search-api.yaml
@@ -1,0 +1,119 @@
+---
+openapi: "3.0.0"
+info:
+  title: GA4GH Discovery Search API
+  description: Definition of GA4GH Discovery Search API
+  termsOfService: https://www.ga4gh.org/
+  contact:
+    email: rishi.nag@ga4gh.org
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: "0.1.0"
+servers: []
+security: []
+paths:
+  /datasets:
+    get:
+      summary: List datasets
+      description: List all datasets exposed by this Search Node.
+      operationId: listDatasets
+      responses:
+        '200':
+          description: The list of available datasets
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListDatasetsResponse"
+        '500':
+          description: An unexpected error occurred
+  /dataset/{dataset_id}:
+    get:
+      summary: Get a dataset
+      description: Returns the first page of the dataset identified by dataset_id.
+      operationId: getDataset
+      parameters:
+        - name: dataset_id
+          in: path
+          description: Unique Dataset ID
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The first page of the requested dataset
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Dataset"
+        '500':
+          description: An unexpected error occurred
+  /search:
+    post:
+      summary: (Placeholder) Perform a search
+      description: Optional operation that accepts a query and returns a dataset
+      operationId: search
+      responses:
+        '404':
+          description: This server does not implement the search operation
+components:
+  schemas:
+    ListDatasetsResponse:
+      required:
+        - datasets
+      type: object
+      properties:
+        datasets:
+          type: array
+          items:
+            $ref: "#/components/schemas/DatasetInfo"
+      additionalProperties: false
+    DatasetInfo:
+      required:
+        - id
+        - schema
+      type: object
+      properties:
+        id:
+          type: string
+          description: Dataset ID
+        location:
+          type: string
+          description: Dataset absolute or relative location
+          format: uri
+        description:
+          type: string
+          description: Optional dataset description
+        schema:
+          $ref: "http://json-schema.org/draft-07/schema#"
+      description: |
+        Describes a dataset hosted by this search node.
+    Dataset:
+      required:
+        - objects
+        - schema
+      type: object
+      properties:
+        schema:
+          $ref: "http://json-schema.org/draft-07/schema#"
+        objects:
+          type: array
+          description: Page of JSON values, each adhering to the schema given in the "schema" property
+          items:
+            # Each item must conform to the schema provided in the "schema" section of this Dataset.
+            # Not sure if this constraint can be expressed in OpenAPI 3.0.
+            type: object
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+      description: A paginated collection of tabular data
+    Pagination:
+      type: object
+      properties:
+        next_page_url:
+          type: string
+          description: URL pointing to the next page of the same dataset. Null or absent on last page.
+          format: uri
+        previous_page_url:
+          type: string
+          description: URL pointing to the previous page of the same dataset. Null or absent on first page.
+          format: uri


### PR DESCRIPTION
This is an early sketch to try and make the discussion around Datasets concrete. Known loose ends include:

- expected error cases (eg. spec 404 for datasets that don’t exist?)
- how to define units (eg. years, kilograms, centimetres, …)
- add pagination for /datasets list resource
- should we use the word ‘schema’ to describe the structure of a dataset? (aligns nicely with JSON Schema, but is overloaded with the typical meaning of ‘schema’ in the relational database sense)
- discussion about how authentication should work (spec could suggest OAuth access tokens? This would dovetail nicely with work that we're aware of/involved in in the Researcher Identity workstream)

Credit: This is derived from earlier API design work done by Michal Linhard at DNAstack.