### PR TITLE
Set up CI based on Travis and OAS Validator, fix #6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: java
+dist: bionic
+sudo: false
+jdk:
+  - openjdk11
+env:
+  - GH_URL=https://raw.githubusercontent.com FILE_TO_VALIDATE=spec/search-api.yaml URL_TO_VALIDATE=$GH_URL/${TRAVIS_PULL_REQUEST_SLUG:-$TRAVIS_REPO_SLUG}/${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}/$FILE_TO_VALIDATE
+before_install:
+  - git clone --branch=v1.0.1 https://github.com/mcupak/oas-validator.git
+  - ./oas-validator/setup-validator.sh
+script:
+  - ./oas-validator/validate.sh "$URL_TO_VALIDATE"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Search
+# Search [![](https://travis-ci.org/ga4gh-discovery/ga4gh-discovery-search.svg?branch=develop)](https://travis-ci.org/ga4gh-discovery/ga4gh-discovery-search) [![](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-discovery-search/develop/LICENSE)
 
 `Search` is a framework for searching genomics and clinical data. 
 


### PR DESCRIPTION
This is the CI setup other ga4gh-discovery repositories are using. The script performs validation of the specification file based on Swagger's validator-badge tool.