### PR TITLE
Add HTTP 404 to /dataset/{id}

### DIFF
--- a/spec/search-api.yaml
+++ b/spec/search-api.yaml
@@ -45,6 +45,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Dataset"
+        '404':
+          description: The requested dataset is not available
         '500':
           description: An unexpected error occurred
   /search:


### PR DESCRIPTION
As there is a possibility that a requested dataset may never exist or may be deleted before the request is made, the endpoint should respond **HTTP 404**.