### PR TITLE
Allow additional properties in table list specification

### DIFF
--- a/spec/search-api.yaml
+++ b/spec/search-api.yaml
@@ -108,7 +108,6 @@ components:
             $ref: "#/components/schemas/Table"
         pagination:
           $ref: '#/components/schemas/Pagination'
-      additionalProperties: false
     Table:
       required:
         - name


### PR DESCRIPTION
Allow implementer of the GET /tables to extend the specification by returning additional properties.

This change:
* Allows to solve specific use cases that are difficult with the spec as written
* Allows to experiment with draft extensions to the upcoming versions of new specifications