### PR TITLE
Remove previous_page_url from Pagination object

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The specification allows for a no-code implementation as a collection of files s
 - ```tables```: served in response to ```GET /tables```
 - ```table/{table_name}/info```: served in response to ```GET /table/{table_name}/info```.  e.g. a table with the name ```mytable``` should have a corresponding file ```table/mytable/info```
 - ```table/{table_name}/data```: served in response to ```GET /table/{table_name}/data```.  e.g. a table with the name ```mytable``` should have a corresponding file ```table/mytable/data```
-- ```table/{table_name}/data_{pageNumber}```, which will be linked in the next_page_url  of the first table  (e.g. ```mytable```), or in the next_page_url/prev_page_url of previous or subsequent pages.
+- ```table/{table_name}/data_{pageNumber}```, which will be linked in the next_page_url of the first table  (e.g. ```mytable```).
 - ```table/{table_name}/data_models/{schemaFile}```: Though not required, data models may be linked via [$ref](https://json-schema.org/latest/json-schema-core.html#rfc.section.8.3). Data models can also be stored as static JSON documents, and be referred to by relative or absolute URLs.
 
 A concrete, example test implementation is [available](https://storage.googleapis.com/ga4gh-tables-example/tables) (list endpoint) with [documentation](https://storage.googleapis.com/ga4gh-tables-example/EXAMPLE.md).

--- a/spec/search-api.yaml
+++ b/spec/search-api.yaml
@@ -150,7 +150,3 @@ components:
           type: string
           description: URL pointing to the next page of the same Table. Null or absent on last page.
           format: uri
-        previous_page_url:
-          type: string
-          description: URL pointing to the previous page of the same Table. Null or absent on first page.
-          format: uri


### PR DESCRIPTION
Remove previous_page_url from Pagination object and update the README.md to remove its reference.

Within the Pagination object, previous_page_url parameter is not useful. Hence, it is better to leave it out of the spec.