### PR TITLE
Replace covidcloud

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -35,7 +35,7 @@ This document describes the overall structure of the Data Connect API and specif
 
 The primary container for data in the Data Connect API is the **Table**. Tables contain rows of data, where each row is a JSON object with key/value pairs. The table describes the structure of its row objects using [JSON Schema](https://json-schema.org/). Row attributes can take on any legal JSON value, e.g. numbers, strings, booleans, nulls, arrays, and nested JSON objects.
 
-The API supports browsing and discovery of data models and table metadata, listing table data, and optionally searching table data using arbitrarily complex expressions including joins and aggregations. The query language is SQL with domain-specific functions to facilitate informative typing of the result fields. 
+The API supports browsing and discovery of data models and table metadata, listing table data, and optionally searching table data using arbitrarily complex expressions including joins and aggregations. The query language is SQL with domain-specific functions to facilitate informative typing of the result fields.
 
 All discovery, browsing and search operations are specified formally in the [OpenAPI specification](https://github.com/ga4gh-discovery/ga4gh-discovery-search/blob/develop/spec/api.yaml) document.
 
@@ -292,7 +292,7 @@ Clients can use the attribute meanings to:
 This system of identifying types through reference URLs is amenable to building up cross-references. With a rich set of cross-references, a Data Connect API client can help join up data from sources that use different nomenclatures, and link concepts to external ontologies.
 
 
-### Example: Semantic Data Types on a Table 
+### Example: Semantic Data Types on a Table
 
 Assume the following JSON Schema is published at https://schemablocks.org/schemas/playground/current/BloodGroup.json:
 
@@ -335,7 +335,7 @@ Assume the following JSON Schema is published at https://schemablocks.org/schema
 
 
 
-Then data exposed through Data Connect API could refer to the concept of “ABO Blood Group” as: 
+Then data exposed through Data Connect API could refer to the concept of “ABO Blood Group” as:
 
 ```
 "$ref": "https://schemablocks.org/schemas/playground/current/BloodGroup.json"
@@ -400,7 +400,7 @@ select
             end
         )
         as row(id varchar, label varchar))
-    end, 
+    end,
     '$ref:https://schemablocks.org/schemas/playground/current/BloodGroup.json') as blood_group
 from pgpc.public.participant
 ```
@@ -456,13 +456,13 @@ The functions listed below SHOULD be supported by any implementation of Data Con
 *   **String manipulation**
     *   `substring(string, start)` → `varchar`
     *   `Concatenation (||)`
-*   **Date manipulation** 
+*   **Date manipulation**
     *   `extract(field FROM date)`
     *   `current_date`
     *   `current_time`
     *   `current_timestamp`
     *   `+`, `-` operators for dates
-*   **Aggregate functions** 
+*   **Aggregate functions**
     *   `count(*)`
     *   `max(x)`
     *   `min(x)`
@@ -475,7 +475,7 @@ An implementation of Data Connect MAY support any number of additional SQL funct
 
 Trino (formerly PrestoSQL) has proven to be a popular choice in existing Data Connect implementations, owing to the highly configurable nature of the engine.  A simplified version of Trino's SQL grammar is presented in [Appendix A](#appendix-a-sql-grammar).
 
-To assist with implementations directly on other database platforms, the [Trino Functions Support Matrix](https://docs.google.com/document/d/1y51qNuoe2ELX9kCOyQbFB4jihiKt2N8Qcd6-zzadIvk) captures differences in the implementation of common functions in granular detail. 
+To assist with implementations directly on other database platforms, the [Trino Functions Support Matrix](https://docs.google.com/document/d/1y51qNuoe2ELX9kCOyQbFB4jihiKt2N8Qcd6-zzadIvk) captures differences in the implementation of common functions in granular detail.
 
 ## Pagination and Long Running Queries
 
@@ -601,24 +601,24 @@ The algorithm provided here simply illustrates one way to comply with the rules 
     5. If there is a pagination object and it has a non-null next_page_url, fetch that URL, make that response the current page, and start back at step 2a; otherwise end.
 
 
-# Supplementary Information 
+# Supplementary Information
 
 This section provides advice to implementers. Nothing in this section is required of a conforming implementation.
 
 
-## Interop with other data storage and transmission standards 
+## Interop with other data storage and transmission standards
 
 This section demonstrates how to expose data stored in commonly used formats using Data Connect Table structures and their embedded JSON schema specifications.
 
 
-### Phenopackets 
+### Phenopackets
 
 Phenopacket is a GA4GH approved standard file format for sharing phenotypic information. A Phenopacket file contains a set of mandatory and optional fields to share information about a patient or participant’s phenotype, such as clinical diagnosis, age of onset, results from lab tests, and disease severity.
 
 
-#### Concrete Example 
+#### Concrete Example
 
-Here is a detailed example of a directory full of Phenopacket files exposed as a single table via the Data Connect API. Each row corresponds to one Phenopacket. The table has two columns: 
+Here is a detailed example of a directory full of Phenopacket files exposed as a single table via the Data Connect API. Each row corresponds to one Phenopacket. The table has two columns:
 
 *   **id**, the ID of that row’s Phenopacket
 *   **phenopacket**, the entire contents of the Phenopacket as a JSON object
@@ -725,26 +725,26 @@ REQUEST:
 ---------------------------------------------------------------------------------------
 WITH pp_genes AS (
   SELECT
-    pp.id AS packet_id, 
+    pp.id AS packet_id,
     json_extract_scalar(g.gene, '$.id') AS gene_id,
     json_extract_scalar(g.gene, '$.symbol') AS gene_symbol
   FROM
-    sample_phenopackets.ga4gh_tables.hpo_phenopackets pp,
-    UNNEST(CAST(json_extract(pp.phenopacket, '$.genes') as ARRAY(json))) 
+    collections.public_datasets.sample_phenopackets_hpo_phenopackets pp,
+    UNNEST(CAST(json_extract(pp.phenopacket, '$.genes') as ARRAY(json)))
       as g (gene)
 )
 SELECT pp_genes.*
-FROM pp_genes 
+FROM pp_genes
 WHERE gene_symbol LIKE 'ANTXR%'
 LIMIT 100;
 RESPONSE:
 ------------------------------------------------------------+-----------------+--------
- PMID:30050362-Schussler-2018-ANTXR2-II-3_                  | NCBIGene:118429 | ANTXR2      
+ PMID:30050362-Schussler-2018-ANTXR2-II-3_                  | NCBIGene:118429 | ANTXR2
  PMID:27587992-Salas-Alanís-2016-ANTXR1-14_year_old_brother | NCBIGene:84168  | ANTXR1
 
 ```
 
-#### Organizing Into Tables 
+#### Organizing Into Tables
 
 Here we demonstrate two possibilities for organizing a collection of Phenopacket JSON files into tables. Other layouts are also possible.
 
@@ -773,7 +773,7 @@ The difference between the two formats is the way in which the Phenopacket JSON 
 *   If certain scopes should only see aggregated data (for privacy reasons), use separate aggregated tables (or views). The connector should only pull data from these pre-summarized views.
 
 
-## Implementing a Federation of SQL Query Nodes 
+## Implementing a Federation of SQL Query Nodes
 
 *   Two approaches: “foreign data wrappers” and “fan-out/hub-and-spoke”
 *   Foreign data wrappers:

--- a/hugo/content/docs/getting-started/consume-data.md
+++ b/hugo/content/docs/getting-started/consume-data.md
@@ -141,7 +141,7 @@ pip install git+https://github.com/DNAstack/search-python-client --no-cache-dir
 ```python
 # Building the query
 from search_python_client.search import SearchClient
-base_url = 'https://data.publisher.dnastack.com'
+base_url = 'https://data.publisher.dnastack.com/data-connect'
 search_client = SearchClient(base_url=base_url)
 query = """
 SELECT Json_extract_scalar(ncpi_disease, '$.code.text')           AS disease,
@@ -185,7 +185,11 @@ devtools::install_github("DNAstack/ga4gh-search-client-r")
 ```R
 # Making the request
 library(httr)
-conditionsInFemalePatients <- ga4gh.search::ga4gh_search("https://data.publisher.dnastack.com", "select json_extract_scalar(ncpi_disease, '$.code.text') as disease, json_extract_scalar(ncpi_disease, '$.identifier[0].value') as identifier from collections.public_datasets.kidsfirst_ncpi_disease disease INNER JOIN collections.public_datasets.kidsfirst_patient patient ON patient.id=replace(json_extract_scalar(ncpi_disease, '$.subject.reference'), 'Patient/') WHERE json_extract_scalar(patient, '$.gender')='female' limit 5")
+<<<<<<< HEAD
+conditionsInFemalePatients <- ga4gh.search::ga4gh_search("https://data.publisher.dnastack.com/data-connect", "select json_extract_scalar(ncpi_disease, '$.code.text') as disease, json_extract_scalar(ncpi_disease, '$.identifier[0].value') as identifier from collections.public_datasets.kidsfirst_ncpi_disease disease INNER JOIN collections.public_datasets.kidsfirst_patient patient ON patient.id=replace(json_extract_scalar(ncpi_disease, '$.subject.reference'), 'Patient/') WHERE json_extract_scalar(patient, '$.gender')='female' limit 5")
+=======
+conditionsInFemalePatients <- ga4gh.search::ga4gh_search("https://data.publisher.dnastack.com/data-connect", "select json_extract_scalar(ncpi_disease, '$.code.text') as disease, json_extract_scalar(ncpi_disease, '$.identifier[0].value') as identifier from collections.public_datasets.ncpi_disease disease INNER JOIN collections.public_datasets.patient patient ON patient.id=replace(json_extract_scalar(ncpi_disease, '$.subject.reference'), 'Patient/') WHERE json_extract_scalar(patient, '$.gender')='female' limit 5")
+>>>>>>> 6f4366c (Corrected the data-connect endpoint and provided fake Trino endpoint for the demo)
 ```
 ```R
 # View the results
@@ -213,7 +217,7 @@ Output:
 {{% tab tabNum="3" %}}
 
 ``` bash
-search-cli query -q "select json_extract_scalar(ncpi_disease, '$.code.text') as disease, json_extract_scalar(ncpi_disease, '$.identifier[0].value') as identifier from collections.public_datasets.kidsfirst_ncpi_disease disease INNER JOIN collections.public_datasets.kidsfirst_patient patient ON patient.id=replace(json_extract_scalar(ncpi_disease, '$.subject.reference'), 'Patient/') WHERE json_extract_scalar(patient, '$.gender')='female' limit 5" --api-url https://data.publisher.dnastack.com
+search-cli query -q "select json_extract_scalar(ncpi_disease, '$.code.text') as disease, json_extract_scalar(ncpi_disease, '$.identifier[0].value') as identifier from collections.public_datasets.kidsfirst_ncpi_disease disease INNER JOIN collections.public_datasets.kidsfirst_patient patient ON patient.id=replace(json_extract_scalar(ncpi_disease, '$.subject.reference'), 'Patient/') WHERE json_extract_scalar(patient, '$.gender')='female' limit 5" --api-url https://data.publisher.dnastack.com/data-connect
 ```
 {{% /tab %}}
 {{% tab tabNum="4" %}}
@@ -221,7 +225,7 @@ These requests
 This query returns all female patients from the `patient` table.
 ``` bash
 curl --request POST \
-  --url https://data.publisher.dnastack.com/search \
+  --url https://data.publisher.dnastack.com/data-connect/search \
   --header 'content-type: application/json' \
   --data '{ "query": "select * from collections.public_datasets.kidsfirst_patient WHERE json_extract_scalar(patient, '\''$.gender'\'')='\''female'\'' limit 5"}'
 ```
@@ -229,7 +233,7 @@ curl --request POST \
 This query returns all conditions observed in female patients from the `patient` table.
 ``` bash
 curl --request POST \
-  --url https://data.publisher.dnastack.com/search \
+  --url https://data.publisher.dnastack.com/data-connect/search \
   --header 'content-type: application/json' \
   --data '{ "query": "select json_extract_scalar(ncpi_disease, '\''$.code.text'\'') as disease, json_extract_scalar(ncpi_disease, '\''$.identifier[0].value'\'') as identifier from collections.public_datasets.kidsfirst_ncpi_disease disease INNER JOIN collections.public_datasets.kidsfirst_patient patient ON patient.id=replace(json_extract_scalar(ncpi_disease, '\''$.subject.reference'\''), '\''Patient/'\'') WHERE json_extract_scalar(patient, '\''$.gender'\'')='\''female'\'' limit 5"}'
 ```
@@ -247,7 +251,7 @@ This is a public implementation of Data Connect. Feel free to follow along with 
 ``` python
 # init search client
 from search_python_client.search import SearchClient
-base_url = 'https://data.publisher.dnastack.com/'
+base_url = 'https://data.publisher.dnastack.com/data-connect/'
 search_client = SearchClient(base_url=base_url)
 ```
 ``` python
@@ -302,7 +306,7 @@ devtools::install_github("DNAstack/ga4gh-search-client-r")
 ``` R
 # Making the request
 library(httr)
-ga4gh.search::ga4gh_list_tables("https://data.publisher.dnastack.com")
+ga4gh.search::ga4gh_list_tables("https://data.publisher.dnastack.com/data-connect")
 ```
 ``` R
 # Select all items from the CPS-II study
@@ -310,17 +314,17 @@ query <- "SELECT * FROM collections.public_datasets.scr_gecco_susceptibility_sub
 ```
 ``` R
 # Executing the query
-ga4gh.search::ga4gh_search("https://data.publisher.dnastack.com", query)
+ga4gh.search::ga4gh_search("https://data.publisher.dnastack.com/data-connect", query)
 ```
 {{% /tab %}}
 {{% tab tabNum="3" %}}
 List tables
 ``` bash
-search-cli list --api-url "https://data.publisher.dnastack.com"
+search-cli list --api-url "https://data.publisher.dnastack.com/data-connect"
 ```
 Get table info
 ``` bash
-search-cli info collections.public_datasets.scr_gecco_susceptibility_subject_phenotypes_multi --api-url "https://data.publisher.dnastack.com"
+search-cli info collections.public_datasets.scr_gecco_susceptibility_subject_phenotypes_multi --api-url "https://data.publisher.dnastack.com/data-connect"
 ```
 Now run a query and pipe the results to a file called `results.txt`
 ``` bash

--- a/hugo/content/docs/getting-started/consume-data.md
+++ b/hugo/content/docs/getting-started/consume-data.md
@@ -141,7 +141,7 @@ pip install git+https://github.com/DNAstack/search-python-client --no-cache-dir
 ```python
 # Building the query
 from search_python_client.search import SearchClient
-base_url = 'https://data.publisher.dnastack.com/data-connect'
+base_url = 'https://publisher-data.publisher.dnastack.com/data-connect'
 search_client = SearchClient(base_url=base_url)
 query = """
 SELECT Json_extract_scalar(ncpi_disease, '$.code.text')           AS disease,
@@ -185,11 +185,7 @@ devtools::install_github("DNAstack/ga4gh-search-client-r")
 ```R
 # Making the request
 library(httr)
-<<<<<<< HEAD
-conditionsInFemalePatients <- ga4gh.search::ga4gh_search("https://data.publisher.dnastack.com/data-connect", "select json_extract_scalar(ncpi_disease, '$.code.text') as disease, json_extract_scalar(ncpi_disease, '$.identifier[0].value') as identifier from collections.public_datasets.kidsfirst_ncpi_disease disease INNER JOIN collections.public_datasets.kidsfirst_patient patient ON patient.id=replace(json_extract_scalar(ncpi_disease, '$.subject.reference'), 'Patient/') WHERE json_extract_scalar(patient, '$.gender')='female' limit 5")
-=======
-conditionsInFemalePatients <- ga4gh.search::ga4gh_search("https://data.publisher.dnastack.com/data-connect", "select json_extract_scalar(ncpi_disease, '$.code.text') as disease, json_extract_scalar(ncpi_disease, '$.identifier[0].value') as identifier from collections.public_datasets.ncpi_disease disease INNER JOIN collections.public_datasets.patient patient ON patient.id=replace(json_extract_scalar(ncpi_disease, '$.subject.reference'), 'Patient/') WHERE json_extract_scalar(patient, '$.gender')='female' limit 5")
->>>>>>> 6f4366c (Corrected the data-connect endpoint and provided fake Trino endpoint for the demo)
+conditionsInFemalePatients <- ga4gh.search::ga4gh_search("https://publisher-data.publisher.dnastack.com/data-connect", "select json_extract_scalar(ncpi_disease, '$.code.text') as disease, json_extract_scalar(ncpi_disease, '$.identifier[0].value') as identifier from collections.public_datasets.kidsfirst_ncpi_disease disease INNER JOIN collections.public_datasets.kidsfirst_patient patient ON patient.id=replace(json_extract_scalar(ncpi_disease, '$.subject.reference'), 'Patient/') WHERE json_extract_scalar(patient, '$.gender')='female' limit 5")
 ```
 ```R
 # View the results
@@ -217,7 +213,7 @@ Output:
 {{% tab tabNum="3" %}}
 
 ``` bash
-search-cli query -q "select json_extract_scalar(ncpi_disease, '$.code.text') as disease, json_extract_scalar(ncpi_disease, '$.identifier[0].value') as identifier from collections.public_datasets.kidsfirst_ncpi_disease disease INNER JOIN collections.public_datasets.kidsfirst_patient patient ON patient.id=replace(json_extract_scalar(ncpi_disease, '$.subject.reference'), 'Patient/') WHERE json_extract_scalar(patient, '$.gender')='female' limit 5" --api-url https://data.publisher.dnastack.com/data-connect
+search-cli query -q "select json_extract_scalar(ncpi_disease, '$.code.text') as disease, json_extract_scalar(ncpi_disease, '$.identifier[0].value') as identifier from collections.public_datasets.kidsfirst_ncpi_disease disease INNER JOIN collections.public_datasets.kidsfirst_patient patient ON patient.id=replace(json_extract_scalar(ncpi_disease, '$.subject.reference'), 'Patient/') WHERE json_extract_scalar(patient, '$.gender')='female' limit 5" --api-url https://publisher-data.publisher.dnastack.com/data-connect
 ```
 {{% /tab %}}
 {{% tab tabNum="4" %}}
@@ -225,7 +221,7 @@ These requests
 This query returns all female patients from the `patient` table.
 ``` bash
 curl --request POST \
-  --url https://data.publisher.dnastack.com/data-connect/search \
+  --url https://publisher-data.publisher.dnastack.com/data-connect/search \
   --header 'content-type: application/json' \
   --data '{ "query": "select * from collections.public_datasets.kidsfirst_patient WHERE json_extract_scalar(patient, '\''$.gender'\'')='\''female'\'' limit 5"}'
 ```
@@ -233,7 +229,7 @@ curl --request POST \
 This query returns all conditions observed in female patients from the `patient` table.
 ``` bash
 curl --request POST \
-  --url https://data.publisher.dnastack.com/data-connect/search \
+  --url https://publisher-data.publisher.dnastack.com/data-connect/search \
   --header 'content-type: application/json' \
   --data '{ "query": "select json_extract_scalar(ncpi_disease, '\''$.code.text'\'') as disease, json_extract_scalar(ncpi_disease, '\''$.identifier[0].value'\'') as identifier from collections.public_datasets.kidsfirst_ncpi_disease disease INNER JOIN collections.public_datasets.kidsfirst_patient patient ON patient.id=replace(json_extract_scalar(ncpi_disease, '\''$.subject.reference'\''), '\''Patient/'\'') WHERE json_extract_scalar(patient, '\''$.gender'\'')='\''female'\'' limit 5"}'
 ```
@@ -251,7 +247,7 @@ This is a public implementation of Data Connect. Feel free to follow along with 
 ``` python
 # init search client
 from search_python_client.search import SearchClient
-base_url = 'https://data.publisher.dnastack.com/data-connect/'
+base_url = 'https://publisher-data.publisher.dnastack.com/data-connect/'
 search_client = SearchClient(base_url=base_url)
 ```
 ``` python
@@ -263,12 +259,12 @@ pprint.pprint(tables)
 ```
 ```python
 #Get more information about a table returned
-table_info = search_client.get_table_info("collections.public_datasets.scr_gecco_susceptibility_subject_phenotypes_multi")
+table_info = search_client.get_table_info("collections.public_datasets.dbgap_scr_gecco_susceptibility_subject_phenotypes_multi")
 pprint.pprint(table_info)
 ```
 ```python
 # Dig into the table a little further
-table_data_iterator = search_client.get_table_data("collections.public_datasets.scr_gecco_susceptibility_subject_phenotypes_multi")
+table_data_iterator = search_client.get_table_data("collections.public_datasets.dbgap_scr_gecco_susceptibility_subject_phenotypes_multi")
 ```
 ```python
 # Limit to first 10 items
@@ -280,7 +276,7 @@ pprint.pprint(tables)
 # Select all items from the CPS-II study
 query = """
 SELECT *
-FROM   collections.public_datasets.scr_gecco_susceptibility_subject_phenotypes_multi
+FROM   collections.public_datasets.dbgap_scr_gecco_susceptibility_subject_phenotypes_multi
 WHERE  study = 'CPS-II'
 LIMIT  5
 """
@@ -306,30 +302,30 @@ devtools::install_github("DNAstack/ga4gh-search-client-r")
 ``` R
 # Making the request
 library(httr)
-ga4gh.search::ga4gh_list_tables("https://data.publisher.dnastack.com/data-connect")
+ga4gh.search::ga4gh_list_tables("https://publisher-data.publisher.dnastack.com/data-connect")
 ```
 ``` R
 # Select all items from the CPS-II study
-query <- "SELECT * FROM collections.public_datasets.scr_gecco_susceptibility_subject_phenotypes_multi WHERE study = 'CPS-II' LIMIT 5"
+query <- "SELECT * FROM collections.public_datasets.dbgap_scr_gecco_susceptibility_subject_phenotypes_multi WHERE study = 'CPS-II' LIMIT 5"
 ```
 ``` R
 # Executing the query
-ga4gh.search::ga4gh_search("https://data.publisher.dnastack.com/data-connect", query)
+ga4gh.search::ga4gh_search("https://publisher-data.publisher.dnastack.com/data-connect", query)
 ```
 {{% /tab %}}
 {{% tab tabNum="3" %}}
 List tables
 ``` bash
-search-cli list --api-url "https://data.publisher.dnastack.com/data-connect"
+search-cli list --api-url "https://publisher-data.publisher.dnastack.com/data-connect"
 ```
 Get table info
 ``` bash
-search-cli info collections.public_datasets.scr_gecco_susceptibility_subject_phenotypes_multi --api-url "https://data.publisher.dnastack.com/data-connect"
+search-cli info collections.public_datasets.dbgap_scr_gecco_susceptibility_subject_phenotypes_multi --api-url "https://publisher-data.publisher.dnastack.com/data-connect"
 ```
 Now run a query and pipe the results to a file called `results.txt`
 ``` bash
-search-cli query -q "SELECT * FROM collections.public_datasets.scr_gecco_susceptibility_subject_phenotypes_multi WHERE study = 'CPS-II' LIMIT 5" \
-  --api-url "https://data.publisher.dnastack.com" > results.txt
+search-cli query -q "SELECT * FROM collections.public_datasets.dbgap_scr_gecco_susceptibility_subject_phenotypes_multi WHERE study = 'CPS-II' LIMIT 5" \
+  --api-url "https://publisher-data.publisher.dnastack.com" > results.txt
 ```
 {{% /tab %}}
 

--- a/hugo/content/docs/getting-started/consume-data.md
+++ b/hugo/content/docs/getting-started/consume-data.md
@@ -86,7 +86,7 @@ This query returns all female patients from the `patient` table.
 ``` SQL
 /* you can scroll on this tab */
 SELECT *
-FROM   collections.public_datasets.patient
+FROM   collections.public_datasets.kidsfirst_patient
 WHERE  Json_extract_scalar(patient, '$.gender') = 'female'
 LIMIT  5;
 ```
@@ -99,8 +99,8 @@ This query returns all conditions observed in female patients from the `patient`
 /* you can scroll on this tab */
 SELECT Json_extract_scalar(ncpi_disease, '$.code.text')           AS disease,
        Json_extract_scalar(ncpi_disease, '$.identifier[0].value') AS identifier
-FROM   collections.public_datasets.ncpi_disease disease
-       INNER JOIN collections.public_datasets.patient patient
+FROM   collections.public_datasets.kidsfirst_ncpi_disease disease
+       INNER JOIN collections.public_datasets.kidsfirst_patient patient
                ON patient.id = REPLACE(Json_extract_scalar(ncpi_disease,
                                        '$.subject.reference'),
                                'Patient/')
@@ -146,8 +146,8 @@ search_client = SearchClient(base_url=base_url)
 query = """
 SELECT Json_extract_scalar(ncpi_disease, '$.code.text')           AS disease,
        Json_extract_scalar(ncpi_disease, '$.identifier[0].value') AS identifier
-FROM   collections.public_datasets.ncpi_disease disease
-       INNER JOIN collections.public_datasets.patient patient
+FROM   collections.public_datasets.kidsfirst_ncpi_disease disease
+       INNER JOIN collections.public_datasets.kidsfirst_patient patient
                ON patient.id = REPLACE(Json_extract_scalar(ncpi_disease,
                                        '$.subject.reference'),
                                'Patient/')
@@ -185,7 +185,7 @@ devtools::install_github("DNAstack/ga4gh-search-client-r")
 ```R
 # Making the request
 library(httr)
-conditionsInFemalePatients <- ga4gh.search::ga4gh_search("https://data.publisher.dnastack.com", "select json_extract_scalar(ncpi_disease, '$.code.text') as disease, json_extract_scalar(ncpi_disease, '$.identifier[0].value') as identifier from collections.public_datasets.ncpi_disease disease INNER JOIN collections.public_datasets.patient patient ON patient.id=replace(json_extract_scalar(ncpi_disease, '$.subject.reference'), 'Patient/') WHERE json_extract_scalar(patient, '$.gender')='female' limit 5")
+conditionsInFemalePatients <- ga4gh.search::ga4gh_search("https://data.publisher.dnastack.com", "select json_extract_scalar(ncpi_disease, '$.code.text') as disease, json_extract_scalar(ncpi_disease, '$.identifier[0].value') as identifier from collections.public_datasets.kidsfirst_ncpi_disease disease INNER JOIN collections.public_datasets.kidsfirst_patient patient ON patient.id=replace(json_extract_scalar(ncpi_disease, '$.subject.reference'), 'Patient/') WHERE json_extract_scalar(patient, '$.gender')='female' limit 5")
 ```
 ```R
 # View the results
@@ -213,7 +213,7 @@ Output:
 {{% tab tabNum="3" %}}
 
 ``` bash
-search-cli query -q "select json_extract_scalar(ncpi_disease, '$.code.text') as disease, json_extract_scalar(ncpi_disease, '$.identifier[0].value') as identifier from collections.public_datasets.ncpi_disease disease INNER JOIN collections.public_datasets.patient patient ON patient.id=replace(json_extract_scalar(ncpi_disease, '$.subject.reference'), 'Patient/') WHERE json_extract_scalar(patient, '$.gender')='female' limit 5" --api-url https://data.publisher.dnastack.com
+search-cli query -q "select json_extract_scalar(ncpi_disease, '$.code.text') as disease, json_extract_scalar(ncpi_disease, '$.identifier[0].value') as identifier from collections.public_datasets.kidsfirst_ncpi_disease disease INNER JOIN collections.public_datasets.kidsfirst_patient patient ON patient.id=replace(json_extract_scalar(ncpi_disease, '$.subject.reference'), 'Patient/') WHERE json_extract_scalar(patient, '$.gender')='female' limit 5" --api-url https://data.publisher.dnastack.com
 ```
 {{% /tab %}}
 {{% tab tabNum="4" %}}
@@ -223,7 +223,7 @@ This query returns all female patients from the `patient` table.
 curl --request POST \
   --url https://data.publisher.dnastack.com/search \
   --header 'content-type: application/json' \
-  --data '{ "query": "select * from collections.public_datasets.patient WHERE json_extract_scalar(patient, '\''$.gender'\'')='\''female'\'' limit 5"}'
+  --data '{ "query": "select * from collections.public_datasets.kidsfirst_patient WHERE json_extract_scalar(patient, '\''$.gender'\'')='\''female'\'' limit 5"}'
 ```
 
 This query returns all conditions observed in female patients from the `patient` table.
@@ -231,7 +231,7 @@ This query returns all conditions observed in female patients from the `patient`
 curl --request POST \
   --url https://data.publisher.dnastack.com/search \
   --header 'content-type: application/json' \
-  --data '{ "query": "select json_extract_scalar(ncpi_disease, '\''$.code.text'\'') as disease, json_extract_scalar(ncpi_disease, '\''$.identifier[0].value'\'') as identifier from collections.public_datasets.ncpi_disease disease INNER JOIN collections.public_datasets.patient patient ON patient.id=replace(json_extract_scalar(ncpi_disease, '\''$.subject.reference'\''), '\''Patient/'\'') WHERE json_extract_scalar(patient, '\''$.gender'\'')='\''female'\'' limit 5"}'
+  --data '{ "query": "select json_extract_scalar(ncpi_disease, '\''$.code.text'\'') as disease, json_extract_scalar(ncpi_disease, '\''$.identifier[0].value'\'') as identifier from collections.public_datasets.kidsfirst_ncpi_disease disease INNER JOIN collections.public_datasets.kidsfirst_patient patient ON patient.id=replace(json_extract_scalar(ncpi_disease, '\''$.subject.reference'\''), '\''Patient/'\'') WHERE json_extract_scalar(patient, '\''$.gender'\'')='\''female'\'' limit 5"}'
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -259,12 +259,12 @@ pprint.pprint(tables)
 ```
 ```python
 #Get more information about a table returned
-table_info = search_client.get_table_info("collections.public_datasets.subject_phenotypes_multi")
+table_info = search_client.get_table_info("collections.public_datasets.scr_gecco_susceptibility_subject_phenotypes_multi")
 pprint.pprint(table_info)
 ```
 ```python
 # Dig into the table a little further
-table_data_iterator = search_client.get_table_data("collections.public_datasets.subject_phenotypes_multi")
+table_data_iterator = search_client.get_table_data("collections.public_datasets.scr_gecco_susceptibility_subject_phenotypes_multi")
 ```
 ```python
 # Limit to first 10 items
@@ -276,7 +276,7 @@ pprint.pprint(tables)
 # Select all items from the CPS-II study
 query = """
 SELECT *
-FROM   collections.public_datasets.subject_phenotypes_multi
+FROM   collections.public_datasets.scr_gecco_susceptibility_subject_phenotypes_multi
 WHERE  study = 'CPS-II'
 LIMIT  5
 """
@@ -306,7 +306,7 @@ ga4gh.search::ga4gh_list_tables("https://data.publisher.dnastack.com")
 ```
 ``` R
 # Select all items from the CPS-II study
-query <- "SELECT * FROM collections.public_datasets.subject_phenotypes_multi WHERE study = 'CPS-II' LIMIT 5"
+query <- "SELECT * FROM collections.public_datasets.scr_gecco_susceptibility_subject_phenotypes_multi WHERE study = 'CPS-II' LIMIT 5"
 ```
 ``` R
 # Executing the query
@@ -320,11 +320,11 @@ search-cli list --api-url "https://data.publisher.dnastack.com"
 ```
 Get table info
 ``` bash
-search-cli info collections.public_datasets.subject_phenotypes_multi --api-url "https://data.publisher.dnastack.com"
+search-cli info collections.public_datasets.scr_gecco_susceptibility_subject_phenotypes_multi --api-url "https://data.publisher.dnastack.com"
 ```
 Now run a query and pipe the results to a file called `results.txt`
 ``` bash
-search-cli query -q "SELECT * FROM collections.public_datasets.subject_phenotypes_multi WHERE study = 'CPS-II' LIMIT 5" \
+search-cli query -q "SELECT * FROM collections.public_datasets.scr_gecco_susceptibility_subject_phenotypes_multi WHERE study = 'CPS-II' LIMIT 5" \
   --api-url "https://data.publisher.dnastack.com" > results.txt
 ```
 {{% /tab %}}

--- a/hugo/content/docs/getting-started/provision-data.md
+++ b/hugo/content/docs/getting-started/provision-data.md
@@ -135,11 +135,11 @@ search-cli list --api-url http://localhost:8089
 ```
 Get table info
 ``` bash
-search-cli info collections.public_datasets.scr_gecco_susceptibility_sample_multi --api-url http://localhost:8089
+search-cli info collections.public_datasets.dbgap_scr_gecco_susceptibility_sample_multi --api-url http://localhost:8089
 ```
 Get table data
 ``` bash
-search-cli data collections.public_datasets.scr_gecco_susceptibility_sample_multi --api-url http://localhost:8089
+search-cli data collections.public_datasets.dbgap_scr_gecco_susceptibility_sample_multi --api-url http://localhost:8089
 ```
 {{% /tab %}}
 

--- a/hugo/content/docs/getting-started/provision-data.md
+++ b/hugo/content/docs/getting-started/provision-data.md
@@ -11,7 +11,7 @@ layout: two-col
 {row-divider}
 #### Implementation
 
-Data Connect requires [table operations](/api/#tag/tables) to be implemented to specification for basic discovery and browsing. 
+Data Connect requires [table operations](/api/#tag/tables) to be implemented to specification for basic discovery and browsing.
 
 Optional but not required, [query operations](/api/#tag/search) may be implemented to support querying with SQL.
 
@@ -60,7 +60,7 @@ You’ll need Docker set up on your system to run the Spring app and the Postgre
 docker pull postgres:latest
 docker run -d --rm --name dnastack-data-connect-db -e POSTGRES_USER=dataconnecttrino -e POSTGRES_PASSWORD=dataconnecttrino -p 15432:5432 postgres
 docker pull dnastack/data-connect-trino:latest
-docker run --rm --name dnastack-data-connect -p 8089:8089 -e TRINO_DATASOURCE_URL=https://trino-public.prod.dnastack.com -e SPRING_DATASOURCE_URL=jdbc:postgresql://host.docker.internal:15432/dataconnecttrino -e SPRING_PROFILES_ACTIVE=no-auth dnastack/data-connect-trino
+docker run --rm --name dnastack-data-connect -p 8089:8089 -e TRINO_DATASOURCE_URL=https://trino.faux.dnastack.com -e SPRING_DATASOURCE_URL=jdbc:postgresql://host.docker.internal:15432/dataconnecttrino -e SPRING_PROFILES_ACTIVE=no-auth dnastack/data-connect-trino
 ```
 {{% /tab %}}
 {{% tab tabNum="2" %}}
@@ -68,7 +68,7 @@ docker run --rm --name dnastack-data-connect -p 8089:8089 -e TRINO_DATASOURCE_UR
 docker pull postgres:latest
 docker run -d --rm --name dnastack-data-connect-db -e POSTGRES_USER=dataconnecttrino -e POSTGRES_PASSWORD=dataconnecttrino -p 15432:5432 postgres
 docker pull dnastack/data-connect-trino:latest
-docker run --rm --name dnastack-data-connect -p 8089:8089 -e TRINO_DATASOURCE_URL=https://trino-public.prod.dnastack.com -e SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:15432/dataconnecttrino -e SPRING_PROFILES_ACTIVE=no-auth dnastack/data-connect-trino
+docker run --rm --name dnastack-data-connect -p 8089:8089 -e TRINO_DATASOURCE_URL=https://trino.faux.dnastack.com -e SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:15432/dataconnecttrino -e SPRING_PROFILES_ACTIVE=no-auth dnastack/data-connect-trino
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -102,13 +102,13 @@ print(tables)
 ```
 ``` python
 # get table info
-table_name = "sample_phenopackets.ga4gh_tables.gecco_phenopackets"
+table_name = "collections.public_datasets.sample_phenopackets_gecco_phenopackets"
 table_info = search_client.get_table_info(table_name)
 print(table_info)
 ```
 ``` python
 # get table data
-table_name = "sample_phenopackets.ga4gh_tables.gecco_phenopackets"
+table_name = "collections.public_datasets.sample_phenopackets_gecco_phenopackets"
 table_data_iterator = search_client.get_table_data(table_name)
 table_data = [next(table_data_iterator, None) for i in range(10)]
 table_data = list(filter(None, table_data))
@@ -124,7 +124,7 @@ print(tables)
 ```
 ``` R
 # Try a query
-search_result <- ga4gh.search::ga4gh_search("http://localhost:8089", "SELECT sample_phenopackets.ga4gh_tables.gecco_phenopackets")
+search_result <- ga4gh.search::ga4gh_search("http://localhost:8089", "SELECT * FROM collections.public_datasets.sample_phenopackets_gecco_phenopackets")
 print(tables)
 ```
 {{% /tab %}}
@@ -135,11 +135,11 @@ search-cli list --api-url http://localhost:8089
 ```
 Get table info
 ``` bash
-search-cli info dbgap_demo.scr_gecco_susceptibility.sample_multi --api-url http://localhost:8089
+search-cli info collections.public_datasets.scr_gecco_susceptibility_sample_multi --api-url http://localhost:8089
 ```
 Get table data
 ``` bash
-search-cli data dbgap_demo.scr_gecco_susceptibility.sample_multi --api-url http://localhost:8089
+search-cli data collections.public_datasets.scr_gecco_susceptibility_sample_multi --api-url http://localhost:8089
 ```
 {{% /tab %}}
 

--- a/hugo/content/docs/use-existing-data/using-trino/doc.md
+++ b/hugo/content/docs/use-existing-data/using-trino/doc.md
@@ -9,7 +9,7 @@ layout: single-col
 ---
 ### The dbGaP GECCO Example
 
-In the [provision data section](/docs/getting-started/provision-data/), we've shown a quick start recipe with the [data-connect-trino](https://github.com/DNAstack/data-connect-trino) docker container connected to a Trino instance hosted at `https://data.publisher.dnastack.com/data-connect/`. This section provides more information on how this was accomplished.
+In the [provision data section](/docs/getting-started/provision-data/), we've shown a quick start recipe with the [data-connect-trino](https://github.com/DNAstack/data-connect-trino) docker container connected to a Trino instance hosted at `https://publisher-data.publisher.dnastack.com/data-connect/`. This section provides more information on how this was accomplished.
 
 {{<code/float-window>}}
 {{%content-textbox%}}
@@ -33,7 +33,7 @@ The following is required before we start.
 1. Java 11+
 1. A Trino server you can access anonymously over HTTP(S).
 1. Git
-> If you don't have a Trino server to work against and you wish to try the app, try using `https://data.publisher.dnastack.com/data-connect/` as the data source.
+> If you don't have a Trino server to work against and you wish to try the app, try using `https://publisher-data.publisher.dnastack.com/data-connect/` as the data source.
 
 **1. Building the Trino Adapter App**
 

--- a/hugo/content/docs/use-existing-data/using-trino/doc.md
+++ b/hugo/content/docs/use-existing-data/using-trino/doc.md
@@ -9,7 +9,7 @@ layout: single-col
 ---
 ### The dbGaP GECCO Example
 
-In the [provision data section](/docs/getting-started/provision-data/), we've shown a quick start recipe with the [data-connect-trino](https://github.com/DNAstack/data-connect-trino) docker container connected to a Trino instance hosted at `https://trino-public.prod.dnastack.com`. This section provides more information on how this was accomplished.
+In the [provision data section](/docs/getting-started/provision-data/), we've shown a quick start recipe with the [data-connect-trino](https://github.com/DNAstack/data-connect-trino) docker container connected to a Trino instance hosted at `https://data.publisher.dnastack.com/data-connect/`. This section provides more information on how this was accomplished.
 
 {{<code/float-window>}}
 {{%content-textbox%}}
@@ -28,12 +28,12 @@ In the [provision data section](/docs/getting-started/provision-data/), we've sh
 {{%/content-textbox%}}
 {{</code/float-window>}}
 
-#### Prerequisites 
+#### Prerequisites
 The following is required before we start.
 1. Java 11+
 1. A Trino server you can access anonymously over HTTP(S).
 1. Git
-> If you don't have a Trino server to work against and you wish to try the app, try using `https://trino-public.prod.dnastack.com` as the data source.
+> If you don't have a Trino server to work against and you wish to try the app, try using `https://data.publisher.dnastack.com/data-connect/` as the data source.
 
 **1. Building the Trino Adapter App**
 
@@ -44,7 +44,7 @@ git clone https://github.com/DNAstack/data-connect-trino.git
 Build the app
 ```bash
 ./mvnw clean package
-``` 
+```
 
 
 **2. Configuration**
@@ -52,7 +52,7 @@ Build the app
 For a minimal configuration, we need a local PostgreSQL database where the app stores its bookkeeping information. By default, the app looks for a local PostgreSQL instance at localhost:5432 with username, password, and database name `dataconnecttrino`. You can spin up such a database with this docker command:
 ```bash
 docker run -d -p 5432:5432 --name data-connect-app-db -e POSTGRES_USER=dataconnecttrino -e POSTGRES_PASSWORD=dataconnecttrino postgres
-``` 
+```
 
 Now you only need to provide two parameters: `PRESTO_DATASOURCE_URL` and `SPRING_PROFILES_ACTIVE`.
 


### PR DESCRIPTION
This PR is to replace all references to the decommissioned Data Connect service (ga4gh-search-presto-adapter-public.prod.dnastack.com) and the soon-to-be-decommissioned Data Connect service (data-connect-trino-public.prod.dnastack.com).

Please be aware that all tables in the queries for the Data Connect services will be updated as well.